### PR TITLE
Replace Dataset.value which was deprecated with h5py 3.0

### DIFF
--- a/bouncing_mnist.py
+++ b/bouncing_mnist.py
@@ -27,8 +27,8 @@ class BouncingMnist():
       print('Please set the correct path to MNIST dataset')
       sys.exit()
 
-    self.data_ = f['train'].value.reshape(-1, 28, 28)
-    #self.test = f['test'].value.reshape(-1, 28, 28)
+    self.data_ = f['train'][()].reshape(-1, 28, 28)
+    #self.test = f['test'][()].reshape(-1, 28, 28)
 
     f.close()
     self.indices_ = np.arange(self.data_.shape[0])

--- a/generate_test_set.py
+++ b/generate_test_set.py
@@ -27,7 +27,7 @@ class MovingMnistTestSetGenerator():
       print('Please set the correct path to MNIST dataset')
       sys.exit()
 
-    self.data_ = f['test'].value.reshape(-1, 28, 28)
+    self.data_ = f['test'][()].reshape(-1, 28, 28)
 
     f.close()
 


### PR DESCRIPTION
See https://docs.h5py.org/en/latest/whatsnew/3.0.html. This was the only issue I had running with PyTorch 1.8 and h5py 3.1.0 (most recent).